### PR TITLE
do not query the table if the entity_ids set is empty

### DIFF
--- a/src/Plugin/better_exposed_filters/filter/Single.php
+++ b/src/Plugin/better_exposed_filters/filter/Single.php
@@ -94,14 +94,14 @@ class Single extends DefaultWidget {
         [$table, $column] = $this->getTableAndColumn();
         $relationship = ($filter->options['relationship']) ? $filter->options['relationship'] : 'base';
         $entityIds = $this->getEntityIds($relationship);
-        $count = \Drupal::database()
+        $count = (!empty($entityIds)) ? \Drupal::database()
           ->select($table, 't')
           ->condition('t.entity_id', $entityIds, 'IN')
           ->condition('t.' . $column, 0, '<>')
           ->fields('t', [$column])
           ->countQuery()
           ->execute()
-          ->fetchField();
+          ->fetchField() : 0;
         if ($count < 1) {
           $form[$field_id]['#access'] = FALSE;
         }


### PR DESCRIPTION
I am extending this filter for TG and come to an error if the results set is empty.
Also I am extending it in TG cause the entityIds for the filters can't be directly queried in the DB.
Ideally we should make an abstract widget with a mandatory function to estimate the number of row available in the view potentially matching the filter. What do you both think?

See also https://github.com/iqual-ch/tg-sw-project/pull/383