### PR TITLE
TG-1140: cache optimization

### DIFF
--- a/src/Plugin/better_exposed_filters/filter/DefaultWidget.php
+++ b/src/Plugin/better_exposed_filters/filter/DefaultWidget.php
@@ -51,15 +51,15 @@ class DefaultWidget extends FilterWidgetBase {
     $view = Views::getView($this->view->id());
     $view->setDisplay($this->view->current_display);
     $view->setArguments($this->view->args);
-    $view->setExposedInput([]);
+    $view->setExposedInput($this->view->getExposedInput());
     $view->setItemsPerPage(0);
     $view->selective_filter = TRUE;
     $view->get_total_rows = TRUE;
 
     // Generate cache id based on total rows view.
-    /** @var Drupal\views\Plugin\views\cache\CachePluginBase $cachePlugin */
-    $cachePlugin = $this->view->display_handler->getPlugin('cache');
-    self::$baseCid[$viewKey] = 'iq_bef_extensions:' . $cachePlugin->generateResultsKey();
+    // Total rows vary on exposed filters, so we include them in the cache id.
+    $exposedInputsHash = md5(json_encode($this->view->getExposedInput()));
+    self::$baseCid[$viewKey] = 'iq_bef_extensions:' . $viewKey . ':entity_ids:' . $exposedInputsHash;
     $cacheBin = \Drupal::cache('data');
 
     // Only retrieve data once per request.
@@ -77,9 +77,8 @@ class DefaultWidget extends FilterWidgetBase {
       }
       else {
 
-        // Execute view to get the data.
-        $view->preExecute();
-        $view->execute();
+        // Build the view to get the query.
+        $view->build();
 
         // Get id key if Search Api is used as the backend.
         if (!$this->view->getQuery() instanceof SearchApiQuery) {
@@ -206,7 +205,7 @@ class DefaultWidget extends FilterWidgetBase {
       try {
         $result = \Drupal::database()->select($table, 't')->condition('t.' . $referenceColumn, $entityIds, 'IN')->fields('t', [$column])->execute();
         foreach ($result as $record) {
-          if ($record->{$column}) {
+          if ($record->{$column} && !in_array($record->{$column}, $ids)) {
             $ids[] = $record->{$column};
           }
         }

--- a/src/Plugin/better_exposed_filters/filter/DefaultWidget.php
+++ b/src/Plugin/better_exposed_filters/filter/DefaultWidget.php
@@ -58,7 +58,7 @@ class DefaultWidget extends FilterWidgetBase {
 
     // Generate cache id based on total rows view.
     // Total rows vary on exposed filters, so we include them in the cache id.
-    $exposedInputsHash = md5(json_encode($this->view->getExposedInput()));
+    $exposedInputsHash = hash('sha256', serialize($this->view->getExposedInput()));
     self::$baseCid[$viewKey] = 'iq_bef_extensions:' . $viewKey . ':entity_ids:' . $exposedInputsHash;
     $cacheBin = \Drupal::cache('data');
 

--- a/src/Plugin/better_exposed_filters/filter/DefaultWidget.php
+++ b/src/Plugin/better_exposed_filters/filter/DefaultWidget.php
@@ -201,12 +201,17 @@ class DefaultWidget extends FilterWidgetBase {
       [$table, $column, $referenceColumn] = $this->getTableAndColumn();
     }
     $ids = [];
+    $idsLookup = [];
     if (!empty($entityIds)) {
       try {
-        $result = \Drupal::database()->select($table, 't')->condition('t.' . $referenceColumn, $entityIds, 'IN')->fields('t', [$column])->execute();
+        $result = \Drupal::database()->select($table, 't')
+          ->condition('t.' . $referenceColumn, $entityIds, 'IN')
+          ->fields('t', [$column])
+          ->execute();
         foreach ($result as $record) {
-          if ($record->{$column} && !in_array($record->{$column}, $ids)) {
+          if ($record->{$column} && !isset($idsLookup[$record->{$column}])) {
             $ids[] = $record->{$column};
+            $idsLookup[$record->{$column}] = TRUE;
           }
         }
       }


### PR DESCRIPTION
## Issue
The option 'Remove unused option' on the iq filter widget can lead to out of memory error on large data set, as it execute a view fully (without pagination), which by default load all entities in memory.

## Fixes
There is no need to execute the view to get a proper query! So by skipping this step we prevent out of memory errors while keeping the standard drupal sql query plugin and cache.