### PR TITLE
DUP-306: Advanced-select compatibility with D11.3.8+

### DIFF
--- a/iq_bef_extensions.libraries.yml
+++ b/iq_bef_extensions.libraries.yml
@@ -1,5 +1,4 @@
 sliders:
-  version: 4.x
   css:
     theme:
       vendor/noUiSlider/nouislider.min.css: { minified: true }
@@ -14,7 +13,6 @@ sliders:
     - core/jquery
 
 advanced_selects:
-  version: 4.0.1
   css:
     theme:
       vendor/select2/css/select2.min.css: { minified: true }
@@ -27,9 +25,9 @@ advanced_selects:
     - core/drupal
     - core/jquery
     - core/once
+    - views/views.ajax
 
 layout_standard:
-  version: 4.x
   css:
     theme:
       resources/css/layout-standard.css: { minified: true }

--- a/resources/js/advanced-selects.js
+++ b/resources/js/advanced-selects.js
@@ -1,4 +1,14 @@
 (function ($, Drupal, drupalSettings, once) {
+
+  // Disable core's SetBrowserUrl AJAX command (Drupal 11+) which writes
+  // exposed filter params into the browser URL. The ajax_view.js constructor
+  // only matches input[name="..."] when reading those params back, missing
+  // <select> elements entirely. This causes stale params to get permanently
+  // baked into the AJAX request URL, breaking filter removal.
+  if (Drupal.AjaxCommands && Drupal.AjaxCommands.prototype.setBrowserUrl) {
+    Drupal.AjaxCommands.prototype.setBrowserUrl = function () { };
+  }
+
   Drupal.behaviors.iq_bef_extensions_advanced_select = {
     attach: function (context, settings) {
 


### PR DESCRIPTION
# Issue
After upgrading to Drupal 11.3.8, exposed filter parameters (e.g. ?field_con_language_target_id[0]=46) started appearing in the browser URL when using AJAX views with Select2 (advanced-select) filters.

This is caused by a new SetBrowserUrl AJAX command in Drupal core's ViewAjaxController that writes filter params into the URL via window.history.replaceState. 

On subsequent interactions, ajax_view.js reads these params back from window.location.search but only matches input elements, missing select elements entirely. This causes stale filter values to become permanently embedded in the AJAX request URL, making it impossible to remove filters (e.g. clicking x on a Select2 tag had no effect).

**Related Drupal Issues:**

- [Views AJAX: Provide UI option to disable SetBrowserUrl and initial ScrollTop behavior on first load with pager](https://www.drupal.org/project/drupal/issues/3586184) 

- [setBrowserUrl guard fails inside iframes : Views AJAX filter state persists across requests](https://www.drupal.org/project/drupal/issues/3586516) 

# Fix
No proper fix from drupal community yet. Therefor I suggest to update our own module:

- Override setBrowserUrl as a no-op in advanced-selects.js:8-10:

`if (Drupal.AjaxCommands && Drupal.AjaxCommands.prototype.setBrowserUrl) {
  Drupal.AjaxCommands.prototype.setBrowserUrl = function () { };
}`

- Add  views/views.ajax as a dependency in iq_bef_extensions.libraries.yml to ensure the prototype exists before the override runs.

This prevents filter params from ever being written to the URL, eliminating the stale-params problem. The override is scoped — it only applies when the iq_bef_extensions advanced-select library is loaded on a page.